### PR TITLE
Valheim: Fix issue preventing graceful stop and world saving

### DIFF
--- a/games/valheim/Dockerfile
+++ b/games/valheim/Dockerfile
@@ -14,7 +14,7 @@ RUN         dpkg --add-architecture i386 \
             && apt upgrade -y \
 			&& apt install -y libcurl4-gnutls-dev:i386 libssl3:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 \
  				gcc g++ libgcc1 libc++-dev gdb libc6 curl tar iproute2 net-tools libatomic1 libsdl1.2debian libsdl2-2.0-0 tzdata \
-        		libfontconfig locales libcurl3-gnutls libpulse-dev libpulse0 libnss-wrapper gettext tini
+        		libfontconfig locales libcurl3-gnutls libpulse-dev libpulse0 libnss-wrapper gettext
 
 ## configure locale
 RUN   update-locale lang=en_US.UTF-8 \
@@ -34,9 +34,6 @@ RUN         touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
 ADD         passwd.template /passwd.template
 
 
-STOPSIGNAL SIGINT
-
 COPY        --chmod=755 --chown=root:root ./entrypoint.sh /entrypoint.sh
 RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/games/valheim/entrypoint.sh
+++ b/games/valheim/entrypoint.sh
@@ -38,6 +38,10 @@ envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
 
 export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
 
+# Trap SIGINT and rethrow it as SIGTERM to ensure compatibility with existing
+# eggs startup command after wings signal handling is fixed.
+trap 'trap - SIGINT && kill -SIGTERM $$' SIGINT
+
 # Replace Startup Variables
 MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
 echo -e ":/home/container$ ${MODIFIED_STARTUP}"


### PR DESCRIPTION
## Description

Remove tini init as the egg already uses signals handlers to handle shutdown and this interferes with it.
Remove incorrect STOPSIGNAL
Rethrow SIGINT's as SIGTERMs to ensure things keep working when wings signal handling issues are resolved.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

