### PR TITLE
Add Brickadia Omegga image

### DIFF
--- a/.github/workflows/games.yml
+++ b/.github/workflows/games.yml
@@ -20,6 +20,7 @@ jobs:
           - arma3
           - dayz
           - mohaa
+          - omegga
           - samp
           - source
           - valheim

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ is tagged correctly.
   * `ghcr.io/pterodactyl/games:mohaa`  
 * [`Multi Theft Auto: San Andreas`](games/mta)
   * `ghcr.io/pterodactyl/games:mta`    
+* [`Brickadia Omegga`](games/omegga)
+  * `ghcr.io/pterodactyl/games:omegga`
 * [`samp`](/games/samp)
   * `ghcr.io/ptero-eggs/games:samp`  
 * [`source`](/games/source)

--- a/games/omegga/Dockerfile
+++ b/games/omegga/Dockerfile
@@ -1,0 +1,38 @@
+FROM        --platform=$TARGETOS/$TARGETARCH node:24-bookworm-slim
+
+LABEL       author="od-e"
+
+ENV         DEBIAN_FRONTEND=noninteractive
+
+RUN         dpkg --add-architecture i386 \
+            && apt-get update \
+            && apt-get upgrade -y \
+            && apt-get install -y tar curl gcc g++ lib32gcc-s1 libgcc-12-dev libgcc-11-dev libcurl4-gnutls-dev:i386 libssl-dev:i386 libcurl4:i386 lib32tinfo6 libtinfo6:i386 lib32z1 lib32stdc++6 libncurses5:i386 libcurl3-gnutls:i386 libsdl2-2.0-0:i386 libsdl2-2.0-0 iproute2 gdb libsdl1.2debian libfontconfig1 telnet net-tools netcat-traditional tzdata numactl xvfb wget tini ffmpeg iproute2 git sqlite3 libsqlite3-dev python3 python3-dev ca-certificates dnsutils tzdata zip tar curl build-essential libtool iputils-ping libnss3 npm \
+            && useradd -m -d /home/container container
+
+## rcon
+RUN         cd /tmp/ \
+            && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
+            && tar xvf rcon.tar.gz \
+            && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
+
+## libssl1.1 fix
+RUN         if [ "$(uname -m)" = "x86_64" ]; then \
+                wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \
+                rm libssl1.1_1.1.0g-2ubuntu4_amd64.deb; \
+            fi
+
+# Have Omegga install SteamCMD without prompt
+ENV         SKIP_STEAMCMD_PROMPT=true
+
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+STOPSIGNAL SIGINT
+
+COPY        --chown=container:container ../entrypoint.sh /entrypoint.sh
+RUN         chmod +x /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
+CMD         ["/entrypoint.sh"]

--- a/games/omegga/entrypoint.sh
+++ b/games/omegga/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+cd /home/container
+
+# Make internal Docker IP address available to processes.
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Print Node.js Version
+node -v
+
+# Replace Startup Variables
+MODIFIED_STARTUP=$(echo -e ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
## Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->
This adds an image that allows Omegga, a Brickadia dedicated server wrapper, to run with all of it's necessary dependencies. Omegga needs access to both Node and SteamCMD (its dependencies) when run; this image combines the existing `node:24-bookworm-slim` image, and the SteamCMD Debian image to allow Omegga to boot and install SteamCMD, then Brickadia.

I have also created a working Omegga egg, which I will open a PR for in the ptero-eggs repository if this is merged.

### All Submissions:

* [x] Have you ensured there aren't other open [Pull Requests](../pulls) for the same update or change?
* [x] Have you created a new branch for your changes and PR from that branch and not from your master branch?

<!-- The new image submission below can be removed if you are not adding a new image -->

### New Image Submissions:

1. [x] Have you added your image to the [Github workflows](https://github.com/parkervcp/yolks/tree/master/.github/workflows)?
2. [x] Have you updated the README list to contain your new image?
