### PR TITLE
Correct user, permissions, entrypoint on Java yolks

### DIFF
--- a/.github/workflows/pr-hadolint.yml
+++ b/.github/workflows/pr-hadolint.yml
@@ -1,0 +1,32 @@
+name: Dockerfile Lint
+
+on:
+  pull_request:
+    paths:
+      - '**/Dockerfile'
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed Dockerfiles
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: |
+            **/Dockerfile
+
+      - name: Run hadolint
+        id: hadolint
+        if: steps.changed-files.outputs.any_changed == 'true'
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:11.0.13_8-jdk-focal
+FROM        eclipse-temurin:11.0.13_8-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/11/Dockerfile
+++ b/java/11/Dockerfile
@@ -20,18 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -4,6 +4,7 @@ LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -17,17 +17,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/11j9/Dockerfile
+++ b/java/11j9/Dockerfile
@@ -1,9 +1,10 @@
-FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-11-jdk
+FROM        ibm-semeru-runtimes:open-11-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:16-jdk-focal
+FROM        eclipse-temurin:16-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/16/Dockerfile
+++ b/java/16/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -4,6 +4,7 @@ LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -17,18 +17,15 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]
 

--- a/java/16j9/Dockerfile
+++ b/java/16j9/Dockerfile
@@ -1,9 +1,10 @@
-FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-16-jdk
+FROM        ibm-semeru-runtimes:open-16-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/17/Dockerfile
+++ b/java/17/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:17-jdk-jammy
+FROM        eclipse-temurin:17-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/19/Dockerfile
+++ b/java/19/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:19-jdk-jammy
+FROM        eclipse-temurin:19-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:21-jdk-jammy
+FROM        eclipse-temurin:21-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/21/Dockerfile
+++ b/java/21/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:22-jdk-jammy
+FROM        eclipse-temurin:22-jdk-jammy
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/22/Dockerfile
+++ b/java/22/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/23/Dockerfile
+++ b/java/23/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/23/Dockerfile
+++ b/java/23/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/23/Dockerfile
+++ b/java/23/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:23-jdk-noble
+FROM        eclipse-temurin:23-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/24/Dockerfile
+++ b/java/24/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/24/Dockerfile
+++ b/java/24/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:24-jdk-noble
+FROM        eclipse-temurin:24-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/24/Dockerfile
+++ b/java/24/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/25/Dockerfile
+++ b/java/25/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/25/Dockerfile
+++ b/java/25/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:25-jdk-noble
+FROM        eclipse-temurin:25-jdk-noble
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/25/Dockerfile
+++ b/java/25/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -7,6 +7,7 @@ LABEL       org.opencontainers.image.licenses=MIT
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -20,17 +20,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/8/Dockerfile
+++ b/java/8/Dockerfile
@@ -1,12 +1,13 @@
-FROM        --platform=$TARGETOS/$TARGETARCH eclipse-temurin:8u312-b07-jdk-focal
+FROM        eclipse-temurin:8u312-b07-jdk-focal
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -4,6 +4,7 @@ LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
 # hadolint ignore=DL3015
 RUN         apt-get update -y \
+            && apt-get upgrade -y \
             && apt-get install -y \
                 curl \
                 lsof \

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -17,17 +17,14 @@ RUN         apt update -y \
                 libfreetype6 \
                 tini \
 				zip \
-				unzip
+				unzip \
+			&& rm -rf /var/lib/apt/lists/*
 
-## Setup user and working directory
-RUN         useradd -m -d /home/container -s /bin/bash container
-USER        container
+## Setup working directory and environment
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container
 
 STOPSIGNAL SIGINT
 
-COPY        --chown=container:container ./../entrypoint.sh /entrypoint.sh
-RUN         chmod +x /entrypoint.sh
-ENTRYPOINT    ["/usr/bin/tini", "-g", "--"]
-CMD         ["/entrypoint.sh"]
+COPY        --chown=root:root --chmod=755 ./../entrypoint.sh /entrypoint.sh
+ENTRYPOINT    ["/usr/bin/tini", "-g", "--", "/entrypoint.sh"]

--- a/java/8j9/Dockerfile
+++ b/java/8j9/Dockerfile
@@ -1,9 +1,10 @@
-FROM        --platform=$TARGETOS/$TARGETARCH ibm-semeru-runtimes:open-8-jdk
+FROM        ibm-semeru-runtimes:open-8-jdk
 
 LABEL       author="Michael Parker" maintainer="parker@pterodactyl.io"
 
-RUN         apt update -y \
-            && apt install -y \
+# hadolint ignore=DL3015
+RUN         apt-get update -y \
+            && apt-get install -y \
                 curl \
                 lsof \
                 ca-certificates \


### PR DESCRIPTION
- Removes unused user account
- Correct file permissions on entrypoint.sh
- Correct ENTRYPOINT config
- Cleanup apt lists
- Remove --platform tags
- Replace apt with apt-get
- Run `apt-get upgrade -y` during build

Added hadolint ignore DL3015 as removing recommended packages would be a material change to the environment and may remove packages that users are currently reliant on.